### PR TITLE
Update setup-go and checkout

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       if: ${{ steps.go-version.outputs.GO_VERSION == '' }}
       run: echo "Go version not defined" && exit 1
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         cache: ${{ inputs.go-cache }}
         go-version: ${{ steps.go-version.outputs.GO_VERSION }}


### PR DESCRIPTION
Bump actions/checkout from v3 to v6 in the repo workflow. Bump actions/setup-go from v5 to v6 in the action itself.

setup-go v6 changes cache keys from go.sum to go.mod - https://github.com/actions/setup-go/issues/478

Mainly for node24 support.